### PR TITLE
[MRG + 1] Allow configuration of listening interface

### DIFF
--- a/excalibur/cli.py
+++ b/excalibur/cli.py
@@ -55,7 +55,7 @@ def webserver(*args, **kwargs):
             initialize_database()
 
     app = create_app(conf)
-    app.run(use_reloader=False)
+    app.run(host=conf.get('webserver', 'web_server_host'), use_reloader=False)
 
 
 @cli.command('worker')

--- a/excalibur/config_templates/default_excalibur.cfg
+++ b/excalibur/config_templates/default_excalibur.cfg
@@ -13,6 +13,11 @@ sql_alchemy_conn = sqlite:///{EXCALIBUR_HOME}/excalibur.db
 logging_level = INFO
 
 [webserver]
+# The host interface on which to listen.
+# 127.0.0.1 means the web server will only respond to requests from the local machine.
+# Set to 0.0.0.0 to listen on all interfaces.
+web_server_host = 127.0.0.1
+
 # The port on which to run the web server.
 web_server_port = 5000
 

--- a/excalibur/config_templates/default_excalibur.cfg
+++ b/excalibur/config_templates/default_excalibur.cfg
@@ -15,7 +15,6 @@ logging_level = INFO
 [webserver]
 # The host interface on which to listen.
 # 127.0.0.1 means the web server will only respond to requests from the local machine.
-# Set to 0.0.0.0 to listen on all interfaces.
 web_server_host = 127.0.0.1
 
 # The port on which to run the web server.


### PR DESCRIPTION
This change will allow configuration of the listening interface for `excalibur webserver`.

I added a config key/value `web_server_host` to the `[webserver]` section of the default config template, along with some explanation.

I updated the call to `app.run()` to use this config value as the `host=` parameter.

This fixes #30 