### PR TITLE
UX: default value for page numbers input set to "all"

### DIFF
--- a/excalibur/www/templates/files.html
+++ b/excalibur/www/templates/files.html
@@ -28,7 +28,7 @@
       <div class="col-md-6 col-sm-6 col-xs-12 py-2">
         <label for="pages">Page numbers (example inputs: 1,3 or 5-8 or 1-end or all)</label>
         <div class="input-group">
-          <input type="text" class="form-control" id="pages" placeholder="Comma-separated page numbers to extract tables from.">
+          <input type="text" class="form-control" id="pages" placeholder="Comma-separated page numbers to extract tables from, or 'all'." value="all">
           <div class="input-group-append">
             <button type="button" id="upload" class="btn btn-outline-secondary">Upload</button>
           </div>


### PR DESCRIPTION
Hello. Thank you for developing this amazing tool.  :heart: :100:   This will save my butt!! My bank only lets me download PDF format for data older than 1 year !! :angry:    

While I was using the application today, I thought it had a bug. I was slightly angered by this. A less patient user may have simply given up on the app all-together at this point.

Here is what happened: I selected a PDF file and then mashed the tab and enter keys to submit the form.  Then I saw there was only 1 page visible.  I thought this was a bug because my PDF has multiple pages and I expected to see them there. 

I believe that most users of this tool are probably going to want to extract all pages by default.  I think any user that explicitly only wants to extract the 1st page will probably look for the page numbers input before they submit the form. 