### PR TITLE
Change the import from werkzeug

### DIFF
--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -7,7 +7,7 @@ import json
 import datetime as dt
 
 import pandas as pd
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 from flask import (Blueprint, jsonify, redirect, render_template, request,
                    send_from_directory, url_for)
 


### PR DESCRIPTION
python 3.6, werkzeug 1.0, on ubuntu 18.04 in WSL (Windows) I couldn't run due to the error
```
from werkzeug import secure_filename
ImportError: cannot import name 'secure_filename'
```