### PR TITLE
Update import from `werkzeug`

### DIFF
--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -7,7 +7,7 @@ import json
 import datetime as dt
 
 import pandas as pd
-from werkzeug import secure_filename
+from werkzeug.utils import secure_filename
 from flask import (Blueprint, jsonify, redirect, render_template, request,
                    send_from_directory, url_for)
 

--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -76,7 +76,7 @@ def files():
 def workspaces(file_id):
     session = Session()
     file = session.query(File).filter(File.file_id == file_id).first()
-    rules = session.query(Rule).order_by(Rule.created_at.desc()).all()
+    session_rules = session.query(Rule).order_by(Rule.created_at.desc()).all()
     session.close()
     imagepaths, saved_rules = (None for i in range(2))
     filedims, imagedims, detected_areas = ('null' for i in range(3))
@@ -93,7 +93,7 @@ def workspaces(file_id):
                 'rule_id': rule.rule_id,
                 'rule_name': rule.rule_name
             }
-            for rule in rules]
+            for rule in session_rules]
     return render_template(
         'workspace.html', filename=file.filename, imagepaths=imagepaths,
         filedims=filedims, imagedims=imagedims, detected_areas=detected_areas,

--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -54,14 +54,14 @@ def files():
         file.save(filepath)
 
         session = Session()
-        f = File(
+        new_file = File(
             file_id=file_id,
             uploaded_at=uploaded_at,
             pages=pages,
             filename=filename,
             filepath=filepath
         )
-        session.add(f)
+        session.add(new_file)
         session.commit()
         session.close()
 
@@ -136,13 +136,13 @@ def rules(rule_id):
         message = 'Rule saved'
 
         session = Session()
-        r = Rule(
+        rule = Rule(
             rule_id=rule_id,
             created_at=created_at,
             rule_name=rule_name,
             rule_options=rule_options
         )
-        session.add(r)
+        session.add(rule)
         session.commit()
         session.close()
     return jsonify(message=message)
@@ -160,13 +160,13 @@ def jobs(job_id):
             data = []
             render_files = json.loads(job.render_files)
             regex = r'page-(\d)+-table-(\d)+'
-            for k in sorted(render_files,
+            for file in sorted(render_files,
                     key=lambda x: (int(re.split(regex, x)[1]), int(re.split(regex, x)[2]))):
-                df = pd.read_json(render_files[k])
-                columns = df.columns.values
-                records = df.to_dict('records')
+                data_frame = pd.read_json(render_files[file])
+                columns = data_frame.columns.values
+                records = data_frame.to_dict('records')
                 data.append({
-                    'title': k,
+                    'title': file,
                     'columns': columns,
                     'records': records
                 })
@@ -199,13 +199,13 @@ def jobs(job_id):
         rule_options = request.form['rule_options']
 
         session = Session()
-        r = Rule(
+        rule = Rule(
             rule_id=rule_id,
             created_at=created_at,
             rule_name=rule_name,
             rule_options=rule_options
         )
-        session.add(r)
+        session.add(rule)
         session.commit()
         session.close()
 
@@ -213,13 +213,13 @@ def jobs(job_id):
     started_at = dt.datetime.now()
 
     session = Session()
-    j = Job(
+    job = Job(
         job_id=job_id,
         started_at=started_at,
         file_id=file_id,
         rule_id=rule_id
     )
-    session.add(j)
+    session.add(job)
     session.commit()
     session.close()
 
@@ -233,13 +233,13 @@ def jobs(job_id):
 @views.route('/download', methods=['POST'])
 def download():
     job_id = request.form['job_id']
-    f = request.form['format']
+    format = request.form['format']
 
     session = Session()
     job = session.query(Job).filter(Job.job_id == job_id).first()
     session.close()
 
-    datapath = os.path.join(job.datapath, f.lower())
+    datapath = os.path.join(job.datapath, format.lower())
     zipfile = glob.glob(os.path.join(datapath, '*.zip'))[0]
 
     directory = os.path.join(os.getcwd(), datapath)

--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -115,7 +115,7 @@ def rules(rule_id):
                 rule_options = json.loads(rule.rule_options)
             return jsonify(message=message, rule_options=rule_options)
         session = Session()
-        rules = session.query(Rule).order_by(Rule.created_at.desc()).all()
+        session_rules = session.query(Rule).order_by(Rule.created_at.desc()).all()
         session.close()
         saved_rules = [
             {
@@ -124,7 +124,7 @@ def rules(rule_id):
                 'rule_name': rule.rule_name,
                 'rule_options': rule.rule_options
             }
-            for rule in rules]
+            for rule in session_rules]
         return render_template('rules.html', saved_rules=saved_rules)
     message='Rule invalid'
     file = request.files['file-0']

--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -159,7 +159,7 @@ def jobs(job_id):
 
             data = []
             render_files = json.loads(job.render_files)
-            regex = 'page-(\d)+-table-(\d)+'
+            regex = r'page-(\d)+-table-(\d)+'
             for k in sorted(render_files,
                     key=lambda x: (int(re.split(regex, x)[1]), int(re.split(regex, x)[2]))):
                 df = pd.read_json(render_files[k])

--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -233,13 +233,13 @@ def jobs(job_id):
 @views.route('/download', methods=['POST'])
 def download():
     job_id = request.form['job_id']
-    format = request.form['format']
+    request_format = request.form['format']
 
     session = Session()
     job = session.query(Job).filter(Job.job_id == job_id).first()
     session.close()
 
-    datapath = os.path.join(job.datapath, format.lower())
+    datapath = os.path.join(job.datapath, request_format.lower())
     zipfile = glob.glob(os.path.join(datapath, '*.zip'))[0]
 
     directory = os.path.join(os.getcwd(), datapath)


### PR DESCRIPTION
`werkzeug` removed many top level attributes ("import magic") in https://github.com/pallets/werkzeug/pull/1644. Now we need to specify the module to import `secure_filename` from.

Fixes https://github.com/camelot-dev/excalibur/issues/90

Fixed all bar 1 of the issues DeepSource reported, [last remaining issue](https://deepsource.io/gh/camelot-dev/excalibur/run/d062456d-0e8f-464e-9ea5-080cc23a2b6a/python/PYL-C0103) is a style issue on line 22...
> ## Name doesn’t conform to conventions
> ### Constant name "views" doesn't conform to UPPER_CASE naming style
> `22:  views = Blueprint('views', __name__)`

Wasn't sure how to fix that one.