### PR TITLE
Navigation 'next' 'prev' links added (Fixes #118)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,9 @@ html_theme_options = {
     'github_repo': 'excalibur',
     'github_banner': True,
     'show_related': False,
+    'show_relbars': True,
+    'show_relbar_top': False,
+    'show_relbar_bottom': True,
     'note_bg': '#FFF59C'
 }
 


### PR DESCRIPTION
Adds navigation links for easy navigation of the Excalibur docs. Requires latest version of Alabaster from their git repo. 
