### PR TITLE
Fix white select area in windows

### DIFF
--- a/excalibur/tasks.py
+++ b/excalibur/tasks.py
@@ -50,7 +50,7 @@ def split(file_id):
             filenames[page] = filename
             filepaths[page] = filepath
             imagenames[page] = imagename
-            imagepaths[page] = imagepath
+            imagepaths[page] = imagepaths[page].replace("\\", "/")
             filedims[page] = get_file_dim(filepath)
             imagedims[page] = get_image_dim(imagepath)
 


### PR DESCRIPTION
CLOSES #5, #82, $142

When running Excalibur in windows, selecting the area where the tables exist whether by your mouse or by autodetect tables shows a white box rather than the document behind it.
Looking at your terminal shows this is because of a 404 as the server can not find the image to show.
For some reason that I have not figured out on windows only, the image path gets mangled and some of the forward slashes are instead replaces with backslashes.

This resolves that issue.
