### PR TITLE
fix: fixes camelot.ext ModuleNotFoundError

### DIFF
--- a/excalibur/tasks.py
+++ b/excalibur/tasks.py
@@ -6,7 +6,7 @@ import datetime as dt
 
 from camelot.core import TableList
 from camelot.parsers import Stream, Lattice
-from camelot.ext.ghostscript import Ghostscript
+from ghostscript import Ghostscript
 
 from . import configuration as conf
 from .models import Job, File, Rule


### PR DESCRIPTION
This, issue camelot-dev/excalibur#144 fixes the ModuleNotFoundError encountered by many on v0.4.3

Let me know I need to make any changes to this PR or provide additional checks.
Thanks to @kylelt for providing this fix in his issue