### PR TITLE
Fix for "No module named camelot.ext" error

### DIFF
--- a/excalibur/tasks.py
+++ b/excalibur/tasks.py
@@ -6,7 +6,7 @@ import datetime as dt
 
 from camelot.core import TableList
 from camelot.parsers import Stream, Lattice
-from camelot.ext.ghostscript import Ghostscript
+from ghostscript import Ghostscript
 
 from . import configuration as conf
 from .models import Job, File, Rule


### PR DESCRIPTION
When i followed the instructions using excalibur I ran into the following issue.

```
Traceback (most recent call last):
  File "/Users/balakumaranpalanivel/.pyenv/versions/3.7.9/bin/excalibur", line 5, in <module>
    from excalibur.cli import cli
  File "/Users/balakumaranpalanivel/ReposPersonal/excaliburRoot/excalibur-fork/excalibur/cli.py", line 8, in <module>
    from .tasks import split, extract
  File "/Users/balakumaranpalanivel/ReposPersonal/excaliburRoot/excalibur-fork/excalibur/tasks.py", line 9, in <module>
    from camelot.ext.ghostscript import Ghostscript
ModuleNotFoundError: No module named 'camelot.ext'
```

There seems to be multiple different ways to fix online.
But the root cause seems to be [this](https://github.com/camelot-dev/camelot/commit/4cebd684bac02b34ab12e2e6b652a9ffbca10bb3) commit where the `ext` folder was removed in camelot but excalibur continues to use it. 


This fix seems to be the most popular one based on [stackoverflow](https://stackoverflow.com/a/69965905/5080325) upvotes and makes sense to me.
But please correct me if am wrong. 

P.S - I had a look at[ contributing guidelines](https://github.com/camelot-dev/excalibur/blob/97eed2654bd8e842b38250417c644c77d0155b7e/CONTRIBUTING.md), i hope i did not miss anything 🤞 