### PR TITLE
Fix send_from_directory param name

### DIFF
--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -260,5 +260,5 @@ def download():
     directory = os.path.join(os.getcwd(), datapath)
     filename = os.path.basename(zipfile)
     return send_from_directory(
-        directory=directory, filename=filename, as_attachment=True
+        directory=directory, path=filename, as_attachment=True
     )


### PR DESCRIPTION
Fixes an exception caused by a parameter name change in `send_from_directory` in newer versions of Flask (changed from `filename` to `path`)

fixes #198 #196