### PR TITLE
Fix: Ensure imagepaths is always a dictionary

### DIFF
--- a/excalibur/www/views.py
+++ b/excalibur/www/views.py
@@ -103,6 +103,8 @@ def workspaces(file_id):
         saved_rules = [
             {"rule_id": rule.rule_id, "rule_name": rule.rule_name} for rule in rules
         ]
+    if not isinstance(imagepaths, dict):
+        imagepaths = {}  # Provide an empty fallback dictionary
     return render_template(
         "workspace.html",
         filename=file.filename,


### PR DESCRIPTION
This patch ensures that the `imagepaths` variable is always a dictionary, 
preventing potential runtime errors when it is unexpectedly `None` or another type.

### Problem Description
After you select a PDF, set "1-end" and push the upload button you get an error message:
![tvnviewer_2025-03-16_13-58-51](https://github.com/user-attachments/assets/26f53f86-9b40-4334-98ff-2af4c7737b27)

### Server log
The server's log has:
```
(map) jlpoole@ryzdesk /usr/local/src/excalibur $ date; excalibur initdb
Sun Mar 16 11:23:40 AM PDT 2025
(map) jlpoole@ryzdesk /usr/local/src/excalibur $ date; excalibur webserver
Sun Mar 16 11:23:50 AM PDT 2025
* Serving Flask app 'excalibur.www.app'
* Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
* Running on http://127.0.0.1:5000
Press CTRL+C to quit
kf.kio.gui: Failed to determine systemd version, falling back to extremely legacy forking mode.
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET / HTTP/1.1" 302 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /files HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/css/base.css HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/css/vendor/bootstrap.min.css HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/js/vendor/jquery-3.3.1.min.js HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/js/vendor/popper.min.js HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/js/files.js HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:23:53] "GET /static/js/vendor/bootstrap.min.js HTTP/1.1" 200 -
127.0.0.1 - - [16/Mar/2025 11:24:05] "POST /files HTTP/1.1" 200 -
[2025-03-16 11:24:05,091] ERROR in app: Exception on /workspaces/9998c443-50b0-4673-bb2e-ea0e04c86c96 [GET]
Traceback (most recent call last):
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/app.py", line 1511, in wsgi_app
response = self.full_dispatch_request()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/app.py", line 919, in full_dispatch_request
rv = self.handle_user_exception(e)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/app.py", line 917, in full_dispatch_request
rv = self.dispatch_request()
^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/app.py", line 902, in dispatch_request
return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/excalibur/www/views.py", line 106, in workspaces
return render_template(
^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/templating.py", line 150, in render_template
return _render(app, template, context)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/flask/templating.py", line 131, in _render
rv = template.render(context)
^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/jinja2/environment.py", line 1304, in render
self.environment.handle_exception()
File "/home/jlpoole/map/lib/python3.12/site-packages/jinja2/environment.py", line 939, in handle_exception
raise rewrite_traceback_stack(source=source)
File "/home/jlpoole/map/lib/python3.12/site-packages/excalibur/www/templates/workspace.html", line 1, in top-level template code
{% extends "base.html" %}
File "/home/jlpoole/map/lib/python3.12/site-packages/excalibur/www/templates/base.html", line 61, in top-level template code
{% block workspace %}{% endblock %}
^^^^^^^^^^^^^^^^^^^^^^^^^
File "/home/jlpoole/map/lib/python3.12/site-packages/excalibur/www/templates/workspace.html", line 12, in block 'workspace'
{% if imagepaths is not none or imagepaths|length == 0 %}
^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object of type 'NoneType' has no len()
127.0.0.1 - - [16/Mar/2025 11:24:05] "GET /workspaces/9998c443-50b0-4673-bb2e-ea0e04c86c96 HTTP/1.1" 500 -
^C
Aborted!
(map) jlpoole@ryzdesk /usr/local/src/excalibur $ date
Sun Mar 16 11:24:23 AM PDT 2025
(map) jlpoole@ryzdesk /usr/local/src/excalibur $
```
I found if I waited a few seconds and then clicked Firefox's refresh button, then I would see the empty work area:
![tvnviewer_2025-03-16_14-30-16](https://github.com/user-attachments/assets/1e37a37f-d941-40df-8fda-64d93a5500e4)

This patch prevents the error page from appearing.  However, there still remains the problem that with the current high watermark, nothing is parsed. Even with this proposed patch, the parsing does not work; the server's log shows:

```
ERROR:root:'PdfReader' object has no attribute 'isEncrypted'
Traceback (most recent call last):
File "/usr/local/src/excalibur/excalibur/tasks.py", line 25, in split
extract_pages, total_pages = get_pages(file.filepath, file.pages)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/src/excalibur/excalibur/utils/task.py", line 38, in get_pages
if infile.isEncrypted:
^^^^^^^^^^^^^^^^^^
AttributeError: 'PdfReader' object has no attribute 'isEncrypted'. Did you mean: 'is_encrypted'?
```
To overcome the above error, I had to apply patch #194 :

   `curl -L https://github.com/camelot-dev/excalibur/pull/194.patch | git apply`

to get parsing to work... but, I still have to refresh my page to see the images:

![tvnviewer_2025-03-16_23-22-10](https://github.com/user-attachments/assets/f0352e2b-db6e-4d44-9c11-19f41c87b465)
